### PR TITLE
Change include install pattern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,8 @@ install(
 )
 
 install(
-    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    FILES "SimpleSignal.h"
     DESTINATION ${include_install_dir}/SimpleSignal
-    FILES_MATCHING PATTERN "*.h"
 )
 
 install(


### PR DESCRIPTION
Current include path: Source/SimpleSignal.h

Expected include path: SimpleSignal/SimpleSignal.h

This should fix it. @ruslo 